### PR TITLE
Update install.rdf

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -32,7 +32,7 @@
             <!-- Seamonkey -->
             <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
             <em:minVersion>2.2</em:minVersion>
-            <em:maxVersion>2.4.*</em:maxVersion>
+            <em:maxVersion>2.26.*</em:maxVersion>
           </RDF:Description>
         </em:targetApplication>         
         <em:localized>


### PR DESCRIPTION
SeaMonkey compatibiliy should be changed to em:maxVersion2.26.*/em:maxVersion. I can comfirm it works up to 2.26.1 (last stable version and used by /me).
